### PR TITLE
[BugFix] Remove hard-coded values

### DIFF
--- a/src/target/codegen_ppl.cc
+++ b/src/target/codegen_ppl.cc
@@ -867,11 +867,14 @@
     std::string cond = PrintExpr(op->args[0]);
     this->PrintIndent();
 
-    // TODO: (xwh)
 
-    std::string op_1_name_ = Downcast<Var>(op->args[1])->name_hint;
-    if (op_1_name_.find("shared") != std::string::npos) {
-      this->stream << "__ppl_tensor_info ";
+    // remove hard code "shared"
+    if (auto var = op->args[1].as<VarNode>()) {
+      std::string op_1_name_ = var->name_hint;
+      auto search = buffer_addrs_.find(var);
+      if (search != buffer_addrs_.end()) {
+        this->stream << "__ppl_tensor_info ";
+      }
     } else {
       PrintType(op->dtype, this->stream);
     }


### PR DESCRIPTION
This pull request includes a change to the `src/target/codegen_ppl.cc` file to improve the handling of variable names and remove hard-coded values.

Codebase improvement:

* [`src/target/codegen_ppl.cc`](diffhunk://#diff-7bb8884416a2d143c61d861dfba81f6b2e1027c8a8f2fd1ef1e93543f92fa01bL870-R877): Removed hard-coded "shared" string and replaced it with a more flexible check using `VarNode` and `buffer_addrs_` to determine if `__ppl_tensor_info` should be used.