### PR TITLE
Fix ppl.rope_add codegen variable redeclaration

### DIFF
--- a/src/target/codegen_ppl.cc
+++ b/src/target/codegen_ppl.cc
@@ -1626,6 +1626,8 @@ void CodeGenTileLangPPL::VisitExpr_(const CallNode *op, std::ostream &os) {
         bytes_size = 2;
       }
       this->PrintIndent();
+      this->stream << "{\n";
+      this->PrintIndent();
       this->stream << "dim4 half_stride;\n";
       this->PrintIndent();
       this->stream << "tpu_aligned_stride(&half_stride, 0, &" << dst << ".shape, " << dtype << ");\n";
@@ -1642,6 +1644,8 @@ void CodeGenTileLangPPL::VisitExpr_(const CallNode *op, std::ostream &os) {
       this->stream << "tpu_bdc_fp_add( " << dst << ".addr, " << even_src0 << ".addr, " << even_src1 << ".addr + " << bytes_size << ", " << "&half_shape, " << "&half_stride, " << "&half_stride, " << "&half_stride, " << dtype << ");\n";
       this->PrintIndent();
       this->stream << "tpu_bdc_fp_add( " << dst << ".addr + " << bytes_size << ", " << odd_src0 << ".addr + " << bytes_size << ", " << odd_src1 << ".addr, " << "&half_shape, " << "&half_stride, " << "&half_stride, " << "&half_stride, " << dtype << ");\n";
+      this->PrintIndent();
+      this->stream << "}\n";
     } else if (op_name == "ppl.gather") {
       auto dst_var   = op->args[1].as<CallNode>()->args[1].as<VarNode>();
       auto param_var = op->args[2].as<CallNode>()->args[1].as<VarNode>();


### PR DESCRIPTION
## Summary

This PR fixes a TPU codegen issue where multiple `T.ppl_rope_add` calls in the same kernel generate duplicated temporary variable declarations, causing C compilation errors.

The fix wraps the generated `ppl.rope_add` code fragment in a local C scope, preventing variables such as `half_stride` and `half_shape` from being redeclared in the same function scope.

## Testing

Tested with a minimal kernel containing two `T.ppl_rope_add` calls in the same `T.Kernel`.

Before this fix, compilation failed with:

```text
error: redeclaration of 'half_stride'
error: redefinition of 'half_shape'
```

After this fix, the kernel compiles successfully.

Fixes #14