### PR TITLE
[Bug] Fix the running jobs of make in setup.py & Add PPL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In short, this repository is about bringing TileLang's programming model to SOPH
 ## Requirements
 
 - Linux and Python 3
-- SOPHGO TPU toolchain environment
+- SOPHGO TPU toolchain environment (requires PPL version <= 1.4.195)
 - Access to BM1690 hardware or a working `cmodel` setup
 
 ## Key TPU Paths

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ cd ../..
 
 ### 2. Build and install
 
+#### 2.1 Build via environment variable
+
 ```bash
 ./install_tpu.sh
+export PYTHONPATH=.
+```
+
+#### 2.2 Build via pip local project
+
+```bash
 pip install -e . -v
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -568,8 +568,10 @@ class CMakeBuild(build_ext):
         # Run CMake to configure the project with the given arguments.
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp)
 
-        # Build the project in "Release" mode with all available CPU cores ("-j").
-        subprocess.check_call(["cmake", "--build", ".", "--config", "Release", "-j"],
+        # Build the project in "Release" mode with 75% available CPU cores (f"-j{num_jobs}").
+        # Other wise, make will use all available cores and it may cause the system to be unresponsive.
+        num_jobs = int(multiprocessing.cpu_count() * 75 / 100)
+        subprocess.check_call(["cmake", "--build", ".", "--config", "Release", f"-j{num_jobs}"],
                               cwd=build_temp)
 
 

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -311,7 +311,7 @@ class LibraryGenerator(object):
 
         def execute_command(cmd, task_name, timeout):
             """Execute a shell command and handle errors"""
-            # fro debug
+            # for debug
             # print(f"\n[{task_name}]")
             # print(f"Command: {cmd}")
             


### PR DESCRIPTION
- Add PPL version requirement (<= 1.4.195)
- Update pip install script: add 75% CPU cores as num_jobs for `-j` parameters.
- Update README: seperate `Build and install` chapter to two parts (Build via environment variable, Build via local pip)
- lint fix: correct spell error `fro` -> `for` in `libgen.py`.